### PR TITLE
feat: (In Progress) Support SASS

### DIFF
--- a/examples/vite-react/config/jest/setupTests.js
+++ b/examples/vite-react/config/jest/setupTests.js
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { jestPreviewConfigure } from 'jest-preview';
 
 jestPreviewConfigure({
-  externalCss: ['src/index.css'],
+  externalCss: ['src/index.css', 'src/global-style.scss'],
 });
 
 window.matchMedia = (query) => ({

--- a/examples/vite-react/config/jest/setupTests.js
+++ b/examples/vite-react/config/jest/setupTests.js
@@ -1,9 +1,4 @@
 import '@testing-library/jest-dom/extend-expect';
-import { jestPreviewConfigure } from 'jest-preview';
-
-jestPreviewConfigure({
-  externalCss: ['src/index.css', 'src/global-style.scss'],
-});
 
 window.matchMedia = (query) => ({
   matches: false,

--- a/examples/vite-react/config/jest/setupTestsBeforeEnv.js
+++ b/examples/vite-react/config/jest/setupTestsBeforeEnv.js
@@ -1,0 +1,6 @@
+import { jestPreviewConfigure } from 'jest-preview';
+
+jestPreviewConfigure({
+  externalCss: ['src/index.css', 'src/global-style.scss'],
+  sassLoadPaths: ['src'], // Root for @use, @import
+});

--- a/examples/vite-react/jest.config.js
+++ b/examples/vite-react/jest.config.js
@@ -6,12 +6,13 @@ module.exports = {
     '!src/mocks/**',
   ],
   coveragePathIgnorePatterns: [],
+  setupFiles: ['./config/jest/setupTestsBeforeEnv.js'],
   setupFilesAfterEnv: ['./config/jest/setupTests.js'],
   testEnvironment: 'jsdom',
   modulePaths: ['<rootDir>/src'],
   transform: {
     '^.+\\.(ts|js|tsx|jsx)$': '@swc/jest',
-    '^.+\\.css$': 'jest-preview/transforms/css',
+    '^.+\\.(css|scss|sass)$': 'jest-preview/transforms/css',
     '^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)':
       'jest-preview/transforms/file',
   },

--- a/examples/vite-react/package-lock.json
+++ b/examples/vite-react/package-lock.json
@@ -1332,6 +1332,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1433,6 +1439,22 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "ci-info": {
       "version": "3.3.0",
@@ -2125,6 +2147,15 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2244,6 +2275,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -2308,6 +2345,15 @@
         "has-bigints": "^1.0.1"
       }
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -2342,6 +2388,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2353,6 +2405,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -9128,6 +9189,15 @@
         "path-type": "^3.0.0"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9211,6 +9281,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "saxes": {
       "version": "5.0.1",

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -30,6 +30,7 @@
     "jest-watch-typeahead": "^1.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.0",
+    "sass": "^1.50.0",
     "typescript": "^4.5.4",
     "vite": "^2.8.0"
   }

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -7,6 +7,7 @@ import logo2 from './assets/images/logo.svg';
 import './App.css';
 import './assets/css/App.css';
 
+import './assets/css/style.scss';
 import styles from './style.module.css';
 
 function App() {
@@ -19,7 +20,10 @@ function App() {
         <p>Vite Example</p>
         <StyledText>This text is styled by styled-components</StyledText>
         <p className={styles.green}>This text is styled by CSS Modules</p>
-
+        <p className="global-configured-sass">
+          This text is styled by global configured SASS
+        </p>
+        <p className="imported-sass">This text is styled by imported SASS</p>
         <p>
           <button
             data-testid="increase"

--- a/examples/vite-react/src/assets/css/style.scss
+++ b/examples/vite-react/src/assets/css/style.scss
@@ -1,0 +1,5 @@
+header {
+  .imported-sass {
+    color: pink;
+  }
+}

--- a/examples/vite-react/src/global-style.scss
+++ b/examples/vite-react/src/global-style.scss
@@ -1,0 +1,5 @@
+header {
+  .global-configured-sass {
+    color: yellow;
+  }
+}

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 // TODO: Need an option for user to manually input css outside tested components
 import './index.css';
+import './style.scss';
 import App from './App';
 
 ReactDOM.render(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,6 +3002,12 @@
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
+    "immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -5731,6 +5737,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "saxes": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prettier": "^2.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "sass": "^1.50.0",
     "styled-components": "^5.3.5",
     "typescript": "^4.6.3",
     "vite": "^2.9.1"

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,12 +1,14 @@
 import path from 'path';
 import fs from 'fs';
+import { CACHE_FOLDER, SASS_LOAD_PATHS_CONFIG } from './constants';
 
 interface JestPreviewConfigOptions {
   externalCss: string[];
+  sassLoadPaths: string[];
 }
 
 export function jestPreviewConfigure(
-  options: JestPreviewConfigOptions = { externalCss: [] },
+  options: JestPreviewConfigOptions = { externalCss: [], sassLoadPaths: [] },
 ) {
   if (!fs.existsSync('./node_modules/.cache/jest-preview-dom')) {
     fs.mkdirSync('./node_modules/.cache/jest-preview-dom', {
@@ -16,13 +18,49 @@ export function jestPreviewConfigure(
 
   options.externalCss.forEach((cssFile) => {
     const basename = path.basename(cssFile);
+
     // Avoid name collision
     // Add `global` to let `jest-preview` server that we want to cache those files
     const destinationBasename = `cache-${basename}`;
-    const destinationFile = path.join(
-      './node_modules/.cache/jest-preview-dom',
-      destinationBasename,
-    );
+    const destinationFile = path.join(CACHE_FOLDER, destinationBasename);
+
+    // If sass file is passed, we need to transform it to css
+    if (cssFile.endsWith('.scss') || cssFile.endsWith('.sass')) {
+      const sass = require('sass');
+
+      // Create cache folder if it doesn't exist
+      if (!fs.existsSync(CACHE_FOLDER)) {
+        fs.mkdirSync(CACHE_FOLDER, {
+          recursive: true,
+        });
+      }
+
+      let sassLoadPaths: string[] = [];
+      // Save sassLoadPaths to cache, so we can use it in the transformer
+      if (options.sassLoadPaths) {
+        sassLoadPaths = options.sassLoadPaths.map(
+          (path) => `${process.cwd()}/${path}`,
+        );
+
+        fs.writeFileSync(
+          path.join(CACHE_FOLDER, SASS_LOAD_PATHS_CONFIG),
+          JSON.stringify(sassLoadPaths),
+        );
+      }
+
+      // Transform sass to css
+      const sassDestinationFile = destinationFile.replace(
+        /\.(scss|sass)$/,
+        '.css',
+      );
+      const sassFile = fs.readFileSync(cssFile, 'utf8');
+      const sassResult = sass.compileString(sassFile, {
+        loadPaths: sassLoadPaths,
+      });
+      fs.writeFileSync(sassDestinationFile, sassResult.css);
+      return;
+    }
+
     // TODO: To move to load file directly instead of cloning them to `.cache`
     // Move together with transform
     // TODO: To cache those files. We cannot cache them by checking if files exists

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const CACHE_FOLDER = './node_modules/.cache/jest-preview-dom';
+export const SASS_LOAD_PATHS_CONFIG = 'cache-sass-load-paths.config';


### PR DESCRIPTION
- Todo: Support @use, @import for SASS
  - Currently, we are using [loadPaths](https://sass-lang.com/documentation/js-api/interfaces/Options#loadPaths) to indicate the path @use and @import should serve, but it is not working.
  - It looks like `loadPaths` is not used in compileString https://github.com/sass/dart-sass/blob/main/lib/src/compile.dart#L97 🤔 
  - Doing the research if we can use [importer](https://github.com/sass/dart-sass/blob/main/lib/src/compile.dart#L98) to solve this problem.

### Features

- [ ] Support SASS
  - Transform SASS file to CSS content, then create <style> tag with CSS content and append to document.
  - Support configured SASS files by transforming SASS files to CSS files, saving CSS files to cache and serving all CSS files by our preview server.

### Chores

- [ ] Move jest preview configure from `setupTests.js` to `setupTestsBeforeEnv.js`, so we can access the configure in transformer if needed.
