### PR TITLE
feat: support non-english characters and responsive design

### DIFF
--- a/demo/__tests__/Translate.test.tsx
+++ b/demo/__tests__/Translate.test.tsx
@@ -1,33 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Translate from '../components/Translate';
 import preview from '../../dist/index';
 
 describe('Translate', () => {
-  it('render hello in English', () => {
+  it('should render in multiple languages', () => {
     render(<Translate />);
     expect(screen.getByText('English: Hello!')).toBeInTheDocument();
-  });
-
-  it('render hello in Korean', () => {
-    render(<Translate />);
     expect(screen.getByText('Korean: 안녕하세요')).toBeInTheDocument();
-    preview.debug();
-  });
-
-  it('render hello in Japanese', () => {
-    render(<Translate />);
     expect(screen.getByText('Japanese: こんにちは')).toBeInTheDocument();
-    preview.debug();
-  });
-
-  it('render hello in Chinese', () => {
-    render(<Translate />);
     expect(screen.getByText('Chinese: 你好')).toBeInTheDocument();
-    preview.debug();
-  });
-
-  it('render hello in Thai', () => {
-    render(<Translate />);
     expect(screen.getByText('Thai: สวัสดี')).toBeInTheDocument();
     preview.debug();
   });

--- a/demo/__tests__/Translate.test.tsx
+++ b/demo/__tests__/Translate.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import Translate from '../components/Translate';
+import preview from '../../dist/index';
+
+describe('Translate', () => {
+  it('render hello in English', () => {
+    render(<Translate />);
+    expect(screen.getByText('English: Hello!')).toBeInTheDocument();
+  });
+
+  it('render hello in Korean', () => {
+    render(<Translate />);
+    expect(screen.getByText('Korean: 안녕하세요')).toBeInTheDocument();
+    preview.debug();
+  });
+
+  it('render hello in Japanese', () => {
+    render(<Translate />);
+    expect(screen.getByText('Japanese: こんにちは')).toBeInTheDocument();
+    preview.debug();
+  });
+
+  it('render hello in Chinese', () => {
+    render(<Translate />);
+    expect(screen.getByText('Chinese: 你好')).toBeInTheDocument();
+    preview.debug();
+  });
+
+  it('render hello in Thai', () => {
+    render(<Translate />);
+    expect(screen.getByText('Thai: สวัสดี')).toBeInTheDocument();
+    preview.debug();
+  });
+});

--- a/demo/components/Translate.tsx
+++ b/demo/components/Translate.tsx
@@ -1,0 +1,14 @@
+const translate = () => {
+  return (
+    <div>
+      <h1>Let's Say Hello in many languages</h1>
+      <p>English: Hello!</p>
+      <p>Korean: 안녕하세요</p>
+      <p>Japanese: こんにちは</p>
+      <p>Chinese: 你好</p>
+      <p>Thai: สวัสดี</p>
+    </div>
+  )
+}
+
+export default translate;

--- a/demo/components/Translate.tsx
+++ b/demo/components/Translate.tsx
@@ -1,4 +1,4 @@
-function translate(){
+function Translate(){
   return (
     <div>
       <h1>Let's Say Hello in many languages</h1>
@@ -11,4 +11,4 @@ function translate(){
   )
 }
 
-export default translate;
+export default Translate;

--- a/demo/components/Translate.tsx
+++ b/demo/components/Translate.tsx
@@ -1,4 +1,4 @@
-const translate = () => {
+function translate(){
   return (
     <div>
       <h1>Let's Say Hello in many languages</h1>

--- a/server/previewServer.js
+++ b/server/previewServer.js
@@ -144,6 +144,8 @@ preview.debug();
 <head>
   <link rel="shortcut icon" href="${FAV_ICON_PATH}">
   <title>Jest Preview Dashboard</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 ${css}
 </head>
 <body>


### PR DESCRIPTION
### Features

- Add `<meta charset="UTF-8">` to html template to be able to render non English characters on Jest Preview Dashboard.
- Add `<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">` to support responsive design on Jest Preview Dashboard.


I added new component `Translate` and add test to it.

![image](https://user-images.githubusercontent.com/8110002/163782775-f651685f-dde9-425f-8475-dca8ca879b1d.png)

