### PR TITLE
chore: Remind users to clearCache after config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ describe('App', () => {
 });
 ```
 
+Or:
+
+```diff
++import { debug } from 'jest-preview';
+
+describe('App', () => {
+  it('should work as expected', () => {
+    render(<App />);
+
++    debug();
+  });
+});
+```
+
 ## Examples
 
 - Use with [Vite](https://vitejs.dev/): [Example with Vite](https://github.com/nvh95/jest-preview/tree/main/examples/vite-react)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,17 @@ moduleNameMapper: {
 },
 ```
 
-### 4. (Optional) Configure external CSS
+### 4. Clear your jest Cache
+
+Since we are updating our transformation code, make sure you clear your jest cache for new changes to take effect.
+
+```bash
+./node_modules/.bin/jest --clearCache
+# Or usually
+npm run test -- --clearCache
+```
+
+### 5. (Optional) Configure external CSS
 
 Sometimes, there are some CSS files imported outside your current test components (e.g: CSS imported in `src/index.js`, `src/main.tsx`). In this case, you can manually add those CSS files to `jest-preview` by `jestPreviewConfigure`. Notice that they should be path from root of your project.
 
@@ -129,7 +139,7 @@ jestPreviewConfigure({
 });
 ```
 
-### 5. (Optional) Configure public folder
+### 6. (Optional) Configure public folder
 
 You don't need to do anything if your public folder is `public`. However, if it's different, you can configure as following:
 

--- a/server/previewServer.js
+++ b/server/previewServer.js
@@ -95,6 +95,17 @@ app.use((req, res, next) => {
     const newPath = path.join(publicFolder, req.url);
     if (fs.existsSync(newPath)) {
       req.url = newPath;
+    } else {
+      // Cannot find the file, warns user about it
+      // Likely user has old Jest cached code transformations.
+      // Or just a bug in their source code
+      console.log('[WARN] File not found: ', req.url);
+      console.log(`[WARN] Please check if ${req.url} is existed.`);
+      console.log(
+        `[WARN] If it is existed, likely you forget to setup the code transformation, or you haven't flushed the old cache yet. Try to run "./node_modules/.bin/jest --clearCache" to clear the cache.\n`,
+      );
+      // TODO: To send those warning to browser as an overlay/ toast, the idea is similar to https://www.npmjs.com/package/vite-plugin-checker
+      // TODO: Known issue: in development, we can't find `favicon.ico` yet. So it will yell in the Preview Server logs
     }
   }
   serve(req, res, next);


### PR DESCRIPTION
### Chores

- [x] Even though we try to invalidate cache when user installs/ updates `jest-preview` in `postinstall`, there is a big chance that user still got cached (install `jest-preview` => run jest => cannot see CSS applies/ cannot see images => go back to config transform). We should let them know.
- [ ] Actually, we can move this part to FAQ. Not sure we should create FAQ part now or wait until we have the docs site(#59)
- [x] Let users know that they can run `debug()` directly