### PR TITLE
chore: Add comments to simplify support for styled-components

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -9,6 +9,8 @@ export function debug(element: Element = document.body): void {
   }
 
   // If user use styled-components
+  // TODO: We actually do not need to write the file, since it's already in `document.head`.
+  // Just try to inject document.head, beside document.body and we can remove following code.
   if (getStyle) {
     // TODO: We can send this data via websocket instead of writing to disk
     fs.writeFileSync(
@@ -20,6 +22,11 @@ export function debug(element: Element = document.body): void {
       },
     );
   }
+
+  // TODO: To write header to header.html
+  // To convert body to body.html
+  // chokidar needs to watch both head and body
+  // CSS Modules and sass should append css to head, instead of body
 
   fs.writeFileSync(
     './node_modules/.cache/jest-preview-dom/index.html',


### PR DESCRIPTION
### Features

- [ ] Do not need to write `styled-component`'s CSS to disk (cache folder)
- [ ] Inject html to `head`, instead of `body`
