### PR TITLE
fix typo

### DIFF
--- a/website/docs/advanced-guides/code-transform.md
+++ b/website/docs/advanced-guides/code-transform.md
@@ -12,7 +12,6 @@ You should use [Pre-configured transformation](/docs/getting-started/installatio
 
 For examples:
 
-````js
 ```javascript
 // config/jest/cssTransform.js
 'use strict';


### PR DESCRIPTION
### Chores

- [x] Fix typo: Remove unnecessary code block notation.