### PR TITLE
Fix global sass on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Make relative filenames consistent between Operating systems.
+- Fix sass on Windows.
 
 ## Chores
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-preview",
-  "version": "0.2.3-alpha.0",
+  "version": "0.2.3-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-preview",
-      "version": "0.2.3-alpha.0",
+      "version": "0.2.3-alpha.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preview",
-  "version": "0.2.3-alpha.0",
+  "version": "0.2.3-alpha.1",
   "description": "Preview your HTML code while using Jest",
   "keywords": [
     "testing",

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -52,7 +52,12 @@ export async function jestPreviewConfigure(
       // As a result, sass.compile cannot find the file
       // TODO: Can we inject css to the `document.head` directly?
       exec(
-        `./node_modules/.bin/sass ${cssFile} ${cssDestinationFile} --no-source-map`,
+        `${path.join(
+          process.cwd(),
+          'node_modules',
+          '.bin',
+          'sass',
+        )} ${cssFile} ${cssDestinationFile} --no-source-map`,
         (err: any) => {
           if (err) {
             console.log(err);


### PR DESCRIPTION
### Fixes

- [x] Fix global sass files error on Windows due to path.
