### PR TITLE
Auto close a issue with `needs-response` tag after 10 days

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,3 +1,5 @@
+# Literally copy from https://github.com/remix-run/remix/blob/889893e9482dcd3edc936e88204a6c3314c45c78/.github/workflows/no-response.yml
+#  Thank you, remix-run/remix
 name: 🥺 No Response
 
 on:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,26 @@
+name: 🥺 No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    if: github.repository == 'nvh95/jest-preview'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🥺 Handle Ghosting
+        uses: lee-dohm/no-response@v0.5.0
+        with:
+          closeComment: >
+            This issue has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from issues that are unactionable. Please reach out if you
+            have more information for us! 💪
+          daysUntilClose: 10
+          responseRequiredLabel: needs-response
+          token: ${{ github.token }}


### PR DESCRIPTION
### Features

- [x] Auto close a issue with `needs-response` tag after 10 days
- [x] Credit to `remix-run/remix` since I know this GitHub Actions while submiting https://github.com/remix-run/remix/pull/3249
