### PR TITLE
docs: rename external CSS => global CSS for easier understanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When writing tests using Jest, we usually debug by reading the HTML code. Someti
   - ✅ Number of CSS-in-JS libraries, such as:
     - ✅ [Styled-components](https://styled-components.com/)
     - ✅ [Emotion](https://emotion.sh/)
-  - ✅ [External CSS](#4-optional-configure-external-css)
+  - ✅ [Global CSS](#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
   - ✅ [Sass](https://sass-lang.com/)
 - 🌄 Support viewing images.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When writing tests using Jest, we usually debug by reading the HTML code. Someti
   - ✅ Number of CSS-in-JS libraries, such as:
     - ✅ [Styled-components](https://styled-components.com/)
     - ✅ [Emotion](https://emotion.sh/)
-  - ✅ [Global CSS](#4-optional-configure-global-css)
+  - ✅ [Global CSS](https://www.jest-preview.com/docs/getting-started/installation#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
   - ✅ [Sass](https://sass-lang.com/)
 - 🌄 Support viewing images.

--- a/website/blog/2022-04-21-introduce-jest-preview-docs/index.md
+++ b/website/blog/2022-04-21-introduce-jest-preview-docs/index.md
@@ -12,7 +12,7 @@ Hello everyone. It's been 17 days from the first version of [Jest Preview](https
 - 💅 Support CSS:
   - ✅ [Direct CSS import](#3-configure-jests-transform-to-intercept-css-and-files)
   - ✅ [Styled-components](https://styled-components.com/)
-  - ✅ [Global CSS](#4-optional-configure-global-css)
+  - ✅ [Global CSS](/docs/getting-started/installation#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
 - 🌄 Support viewing images.
 

--- a/website/blog/2022-04-21-introduce-jest-preview-docs/index.md
+++ b/website/blog/2022-04-21-introduce-jest-preview-docs/index.md
@@ -12,7 +12,7 @@ Hello everyone. It's been 17 days from the first version of [Jest Preview](https
 - 💅 Support CSS:
   - ✅ [Direct CSS import](#3-configure-jests-transform-to-intercept-css-and-files)
   - ✅ [Styled-components](https://styled-components.com/)
-  - ✅ [External CSS](#4-optional-configure-external-css)
+  - ✅ [Global CSS](#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
 - 🌄 Support viewing images.
 

--- a/website/docs/getting-started/features.md
+++ b/website/docs/getting-started/features.md
@@ -11,7 +11,7 @@ sidebar_position: 2
   - ✅ Number of CSS-in-JS libraries, such as:
     - ✅ [Styled-components](https://styled-components.com/)
     - ✅ [Emotion](https://emotion.sh/)
-  - ✅ [External CSS](#4-optional-configure-external-css)
+  - ✅ [Global CSS](#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
   - ✅ [Sass](https://sass-lang.com/)
 - 🌄 Support viewing images.

--- a/website/docs/getting-started/features.md
+++ b/website/docs/getting-started/features.md
@@ -11,7 +11,7 @@ sidebar_position: 2
   - ✅ Number of CSS-in-JS libraries, such as:
     - ✅ [Styled-components](https://styled-components.com/)
     - ✅ [Emotion](https://emotion.sh/)
-  - ✅ [Global CSS](#4-optional-configure-global-css)
+  - ✅ [Global CSS](/docs/getting-started/installation#4-optional-configure-global-css)
   - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
   - ✅ [Sass](https://sass-lang.com/)
 - 🌄 Support viewing images.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ moduleNameMapper: {
 },
 ```
 
-### 4. (Optional) Configure external CSS
+### 4. (Optional) Configure global CSS
 
 Sometimes, there are some CSS files imported outside your current test components (e.g: CSS imported in `src/index.js`, `src/main.tsx`). In this case, you can manually add those CSS files to jest setup file.
 

--- a/website/docs/others/faq.md
+++ b/website/docs/others/faq.md
@@ -10,7 +10,7 @@ There are a few reasons that you might not see CSS on the Jest Preview Dashboard
 
 - Jest Preview generally uses [Code Transformation](https://jestjs.io/docs/code-transformation) to process CSS. You might forget to configure the `transform` in your Jest's config. Please see [**Installation**](/docs/getting-started/installation) for more. If you are using [Create React App](https://create-react-app.dev/), you might want to visit [CRA Example](/docs/examples/create-react-app). If you are using [Next.js](https://nextjs.org/), you might want to visit [Next.js example](/docs/examples/next-rust).
 - If you already configure CSS transform, there is a very high chance that Jest is caching your CSS files. Please [**delete Jest's cache**](https://jestjs.io/docs/cli#--clearcache) by running `jest --clearCache`.
-- You might have some CSS files that are not imported to your current testing component (i.e: `src/index.jsx`, `src/main.jsx`). You can configure external CSS using `jestPreviewConfigure`. See more at [**Installation**](/docs/getting-started/installation#4-optional-configure-external-css).
+- You might have some CSS files that are not imported to your current testing component (i.e: `src/index.jsx`, `src/main.jsx`). You can configure global CSS using `jestPreviewConfigure`. See more at [**Installation**](/docs/getting-started/installation#4-optional-configure-global-css).
 
 ```js
 // src/setupTests.js


### PR DESCRIPTION
## Motivation

People forgot to configure **external** CSS in `setupTest.js`/ `jest.setup.js`. We rename **external CSS** => **global CSS**. So users get familiar with it more. And hope they don't forget to configure **global CSS**.

## Chores

- [x] rename external CSS => global CSS for easier understanding

