### PR TITLE
Deprecate externalCss in 0.3.1

### DIFF
--- a/website/blog/2022-06-11-deprecate-externalCss/index.md
+++ b/website/blog/2022-06-11-deprecate-externalCss/index.md
@@ -23,7 +23,7 @@ Previous Jest Preview provides a way to configure external CSS via `externalCss`
 
 `externalCss` is not recommended to use anymore. Please do not use it. We are planning to remove it gradually with this road map:
 
-> - 0.2.4: Add a warning to warn users if they use `externalCss`.
+> - [0.2.4](https://github.com/nvh95/jest-preview/releases/tag/v0.2.4): Add a warning to warn users if they use `externalCss`.
 > - 0.3.0: Remove the code to process `externalCss` in `jestPreviewConfigure`, show an error if users use `externalCss`.
 > - 0.4.0: Throw an error if users configure `externalCss`.
 > - 0.5.0: Remove `externalCss` completely.


### PR DESCRIPTION
## Feature
- [x] Deprecate externalCSS in 0.3.1. More context here: https://github.com/nvh95/jest-preview/issues/124#issuecomment-1140130106

## Note
- Do not merge it yet. Leave it for `0.3.1`