### PR TITLE
Use vite internally instead of handling live update with websocket, chokidar

### DIFF
--- a/cli/server/previewServer.js
+++ b/cli/server/previewServer.js
@@ -5,185 +5,151 @@ const fs = require('fs');
 const connect = require('connect');
 const sirv = require('sirv');
 const app = connect();
-const chokidar = require('chokidar');
 const { openBrowser } = require('./browser');
-const { WebSocketServer } = require('ws');
 
-const port = process.env.PORT || 3336;
-// TODO: Can we reuse `port`, I think Vite they can do that
-// https://github.com/vitejs/vite/blob/50a876537cc7b934ec5c1d11171b5ce02e3891a8/packages/vite/src/node/server/ws.ts#L97
-// TODO: Increase port by 1 is not a good strategy, we should check if it's also available
-const wsPort = Number(port) + 1;
+const { createServer: createViteServer } = require('vite');
 
-const CACHE_DIRECTORY = './node_modules/.cache/jest-preview';
-const INDEX_BASENAME = 'index.html';
-const INDEX_PATH = path.join(CACHE_DIRECTORY, INDEX_BASENAME);
-const PUBLIC_CONFIG_BASENAME = 'cache-public.config';
-const PUBLIC_CONFIG_PATH = path.join(CACHE_DIRECTORY, PUBLIC_CONFIG_BASENAME);
-const FAV_ICON_PATH = './node_modules/jest-preview/cli/server/favicon.ico';
-
-// Always set default public folder to `public` if not specified
-let publicFolder = 'public';
-
-if (fs.existsSync(PUBLIC_CONFIG_PATH)) {
-  publicFolder = fs.readFileSync(PUBLIC_CONFIG_PATH, 'utf8').trim();
-}
-
-const wss = new WebSocketServer({ port: wsPort });
-
-wss.on('connection', function connection(ws) {
-  ws.on('message', function message(data) {
-    console.log('received: %s', data);
-    try {
-      const dataJSON = JSON.parse(data);
-      if (dataJSON.type === 'publicFolder') {
-        publicFolder = dataJSON.payload;
-      }
-    } catch (error) {
-      console.error(error);
-    }
+async function createServer() {
+  const vite = await createViteServer({
+    server: { middlewareMode: 'ssr' },
+    configFile: path.resolve(__dirname, './vite.config.js'),
   });
-});
 
-const watcher = chokidar.watch([INDEX_PATH, PUBLIC_CONFIG_PATH], {
-  // ignored: ['**/node_modules/**', '**/.git/**'],
-  ignoreInitial: true,
-  ignorePermissionErrors: true,
-  disableGlobbing: true,
-});
+  const port = process.env.PORT || 3336;
 
-function handleFileChange(filePath) {
-  const basename = path.basename(filePath);
-  // TODO: Check if this is the root cause for issue on linux
-  if (basename === INDEX_BASENAME) {
-    wss.clients.forEach((client) => {
-      if (client.readyState === 1) {
-        client.send(JSON.stringify({ type: 'reload' }));
-      }
-    });
-  }
+  const CACHE_DIRECTORY = './node_modules/.cache/jest-preview';
+  const INDEX_BASENAME = 'index.html';
+  const INDEX_PATH = path.join(CACHE_DIRECTORY, INDEX_BASENAME);
+  const PUBLIC_CONFIG_BASENAME = 'cache-public.config';
+  const PUBLIC_CONFIG_PATH = path.join(CACHE_DIRECTORY, PUBLIC_CONFIG_BASENAME);
+  const FAV_ICON_PATH = './node_modules/jest-preview/cli/server/favicon.ico';
 
-  if (basename === PUBLIC_CONFIG_BASENAME) {
+  // Always set default public folder to `public` if not specified
+  let publicFolder = 'public';
+
+  if (fs.existsSync(PUBLIC_CONFIG_PATH)) {
     publicFolder = fs.readFileSync(PUBLIC_CONFIG_PATH, 'utf8').trim();
   }
-}
 
-watcher
-  .on('change', handleFileChange)
-  .on('add', handleFileChange)
-  .on('unlink', handleFileChange);
-
-/**
- *
- * @param {string} string
- * @param {string} word
- * @param {string} injectWord
- * @returns string
- */
-
-function injectToString(string, word, injectWord) {
-  const breakPosition = string.indexOf(word) + word.length;
-  return (
-    string.slice(0, breakPosition) + injectWord + string.slice(breakPosition)
-  );
-}
-
-function injectToHead(html, content) {
-  return injectToString(html, '<head>', content);
-}
-
-app.use((req, res, next) => {
-  // Learn from https://github.com/vitejs/vite/blob/2b7dad1ea1d78d7977e0569fcca4c585b4014e85/packages/vite/src/node/server/middlewares/static.ts#L38
-  const serve = sirv('.', {
-    dev: true,
-    etag: true,
-  });
-  // Do not serve index
-  if (req.url === '/') {
-    return next();
+  function injectToString(string, word, injectWord) {
+    const breakPosition = string.indexOf(word) + word.length;
+    return (
+      string.slice(0, breakPosition) + injectWord + string.slice(breakPosition)
+    );
   }
 
-  // Check if req.url is existed, if not, look up in public directory
-  const filePath = path.join('.', req.url);
-  if (!fs.existsSync(filePath)) {
-    const newPath = path.join(publicFolder, req.url);
-    if (fs.existsSync(newPath)) {
-      req.url = newPath;
-    } else {
-      // Cannot find the file, warns user about it
-      // Likely user has old Jest cached code transformations.
-      // Or just a bug in their source code
-      console.log('[WARN] File not found: ', req.url);
-      console.log(`[WARN] Please check if ${req.url} is existed.`);
-      console.log(
-        `[WARN] If it is existed, likely you forget to setup the code transformation, or you haven't flushed the old cache yet. Try to run "./node_modules/.bin/jest --clearCache" to clear the cache.\n`,
-      );
-      // TODO: To send those warning to browser as an overlay/ toast, the idea is similar to https://www.npmjs.com/package/vite-plugin-checker
-      // TODO: Known issue: in development, we can't find `favicon.ico` yet. So it will yell in the Preview Server logs
+  function injectToHead(html, content) {
+    return injectToString(html, '<head>', content);
+  }
+
+  app.use(vite.middlewares);
+
+  app.use((req, res, next) => {
+    // Learn from https://github.com/vitejs/vite/blob/2b7dad1ea1d78d7977e0569fcca4c585b4014e85/packages/vite/src/node/server/middlewares/static.ts#L38
+    const serve = sirv('.', {
+      dev: true,
+      etag: true,
+    });
+    // Do not serve index
+    if (req.url === '/') {
+      return next();
     }
-  }
-  serve(req, res, next);
-});
 
-app.use('/', (req, res) => {
-  const reloadScriptContent = fs
-    .readFileSync(path.join(__dirname, './ws-client.js'), 'utf-8')
-    .replace(/\$PORT/g, wsPort);
+    // Check if req.url is existed, if not, look up in public directory
+    const filePath = path.join('.', req.url);
+    if (!fs.existsSync(filePath)) {
+      const newPath = path.join(publicFolder, req.url);
+      if (fs.existsSync(newPath)) {
+        req.url = newPath;
+      } else {
+        // Cannot find the file, warns user about it
+        // Likely user has old Jest cached code transformations.
+        // Or just a bug in their source code
+        console.log('[WARN] File not found: ', req.url);
+        console.log(`[WARN] Please check if ${req.url} is existed.`);
+        console.log(
+          `[WARN] If it is existed, likely you forget to setup the code transformation, or you haven't flushed the old cache yet. Try to run "./node_modules/.bin/jest --clearCache" to clear the cache.\n`,
+        );
+        // TODO: To send those warning to browser as an overlay/ toast, the idea is similar to https://www.npmjs.com/package/vite-plugin-checker
+        // TODO: Known issue: in development, we can't find `favicon.ico` yet. So it will yell in the Preview Server logs
+      }
+    }
+    serve(req, res, next);
+  });
 
-  if (!fs.existsSync(INDEX_PATH)) {
-    // Make it looks nice
-    return res.end(`<!DOCTYPE html>
-<html>
-<head>
-  <link rel="shortcut icon" href="${FAV_ICON_PATH}">
-  <title>Jest Preview Dashboard</title>
-</head>
-<body>
-No preview found.<br/>
-Please add following lines to your test: <br /> <br />
-<div style="background-color: grey;width: fit-content;padding: 8px;">
-  <code>
-  import { debug } from 'jest-preview';
-  <br />
-  <br />
-  // Inside your tests
-  <br />
-  debug();
-  </code>
-</div>
-<br />
-Then rerun your tests.
-<br />
-See an example in the <a href="https://www.jest-preview.com/docs/getting-started/usage#3-preview-your-html-from-jest-following-code-demo-how-to-use-it-with-react-testing-library" target="_blank" rel="noopener noreferrer">documentation</a>
-</body>
-<script>${reloadScriptContent}</script>
-</html>`);
-  }
-  let indexHtml = fs.readFileSync(INDEX_PATH, 'utf8');
-  indexHtml += `<script>${reloadScriptContent}</script>`;
-  indexHtml = injectToHead(
-    indexHtml,
-    `<link rel="shortcut icon" href="${FAV_ICON_PATH}">
+  app.use('/', async (req, res) => {
+    let indexHtml = fs.readFileSync(INDEX_PATH, 'utf8');
+    indexHtml = injectToHead(
+      indexHtml,
+      `<link rel="shortcut icon" href="${FAV_ICON_PATH}">
   <title>Jest Preview Dashboard</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">`,
-  );
-  res.end(indexHtml);
-});
+    );
+    indexHtml = injectToHead(
+      indexHtml,
+      `<script type="module" src="/@vite/client"></script>
+    <script type="module">
+  import RefreshRuntime from "/@react-refresh"
+  RefreshRuntime.injectIntoGlobalHook(window)
+  window.$RefreshReg$ = () => {}
+  window.$RefreshSig$ = () => (type) => type
+  window.__vite_plugin_react_preamble_installed__ = true
+  </script>`,
+    );
+    res.end(indexHtml);
+  });
 
-const server = http.createServer(app);
+  const server = http.createServer(app);
 
-server.listen(port, () => {
-  if (fs.existsSync(INDEX_PATH)) {
-    // Remove old preview
-    const files = fs.readdirSync(CACHE_DIRECTORY);
-    files.forEach((file) => {
-      if (!file.startsWith('cache-')) {
-        fs.unlinkSync(path.join(CACHE_DIRECTORY, file));
-      }
-    });
-  }
+  server.listen(port, () => {
+    if (fs.existsSync(INDEX_PATH)) {
+      // Remove old preview
+      const files = fs.readdirSync(CACHE_DIRECTORY);
+      files.forEach((file) => {
+        if (!file.startsWith('cache-')) {
+          fs.unlinkSync(path.join(CACHE_DIRECTORY, file));
+        }
+      });
+    }
 
-  console.log(`Jest Preview Server listening on port ${port}`);
-  openBrowser(`http://localhost:${port}`);
-});
+    if (!fs.existsSync(CACHE_DIRECTORY)) {
+      fs.mkdirSync(CACHE_DIRECTORY, {
+        recursive: true,
+      });
+    }
+    fs.writeFileSync(
+      INDEX_PATH,
+      `<!DOCTYPE html>
+    <html>
+    <head>
+      <link rel="shortcut icon" href="${FAV_ICON_PATH}">
+      <title>Jest Preview Dashboard</title>
+    </head>
+    <body>
+    No preview found.<br/>
+    Please add following lines to your test: <br /> <br />
+    <div style="background-color: grey;width: fit-content;padding: 8px;">
+      <code>
+      import { debug } from 'jest-preview';
+      <br />
+      <br />
+      // Inside your tests
+      <br />
+      debug();
+      </code>
+    </div>
+    <br />
+    Then rerun your tests.
+    <br />
+    See an example in the <a href="https://www.jest-preview.com/docs/getting-started/usage#3-preview-your-html-from-jest-following-code-demo-how-to-use-it-with-react-testing-library" target="_blank" rel="noopener noreferrer">documentation</a>
+    </body>
+    </html>`,
+    );
+
+    console.log(`Jest Preview Server listening on port ${port}`);
+    openBrowser(`http://localhost:${port}`);
+  });
+}
+
+createServer();

--- a/cli/server/previewServer.js
+++ b/cli/server/previewServer.js
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-// We can move this file to globalSetup, globalTeardown
-// Reference:
-// - https://jestjs.io/docs/puppeteer
-// - https://jestjs.io/docs/configuration#globalsetup-string
-// No, we can't. Since jest will terminate the express server after test finish running
-
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
@@ -22,10 +16,8 @@ const port = process.env.PORT || 3336;
 const wsPort = Number(port) + 1;
 
 const CACHE_DIRECTORY = './node_modules/.cache/jest-preview';
-const HEAD_BASENAME = 'head.html';
-const HEAD_PATH = path.join(CACHE_DIRECTORY, HEAD_BASENAME);
-const BODY_BASENAME = 'body.html';
-const BODY_PATH = path.join(CACHE_DIRECTORY, BODY_BASENAME);
+const INDEX_BASENAME = 'index.html';
+const INDEX_PATH = path.join(CACHE_DIRECTORY, INDEX_BASENAME);
 const PUBLIC_CONFIG_BASENAME = 'cache-public.config';
 const PUBLIC_CONFIG_PATH = path.join(CACHE_DIRECTORY, PUBLIC_CONFIG_BASENAME);
 const FAV_ICON_PATH = './node_modules/jest-preview/cli/server/favicon.ico';
@@ -53,7 +45,7 @@ wss.on('connection', function connection(ws) {
   });
 });
 
-const watcher = chokidar.watch([BODY_PATH, PUBLIC_CONFIG_PATH], {
+const watcher = chokidar.watch([INDEX_PATH, PUBLIC_CONFIG_PATH], {
   // ignored: ['**/node_modules/**', '**/.git/**'],
   ignoreInitial: true,
   ignorePermissionErrors: true,
@@ -62,8 +54,8 @@ const watcher = chokidar.watch([BODY_PATH, PUBLIC_CONFIG_PATH], {
 
 function handleFileChange(filePath) {
   const basename = path.basename(filePath);
-  // Do not need to watch for HEAD_BASENAME, since we write head.html before body.html
-  if (basename === BODY_BASENAME) {
+  // TODO: Check if this is the root cause for issue on linux
+  if (basename === INDEX_BASENAME) {
     wss.clients.forEach((client) => {
       if (client.readyState === 1) {
         client.send(JSON.stringify({ type: 'reload' }));
@@ -80,6 +72,25 @@ watcher
   .on('change', handleFileChange)
   .on('add', handleFileChange)
   .on('unlink', handleFileChange);
+
+/**
+ *
+ * @param {string} string
+ * @param {string} word
+ * @param {string} injectWord
+ * @returns string
+ */
+
+function injectToString(string, word, injectWord) {
+  const breakPosition = string.indexOf(word) + word.length;
+  return (
+    string.slice(0, breakPosition) + injectWord + string.slice(breakPosition)
+  );
+}
+
+function injectToHead(html, content) {
+  return injectToString(html, '<head>', content);
+}
 
 app.use((req, res, next) => {
   // Learn from https://github.com/vitejs/vite/blob/2b7dad1ea1d78d7977e0569fcca4c585b4014e85/packages/vite/src/node/server/middlewares/static.ts#L38
@@ -119,7 +130,7 @@ app.use('/', (req, res) => {
     .readFileSync(path.join(__dirname, './ws-client.js'), 'utf-8')
     .replace(/\$PORT/g, wsPort);
 
-  if (!fs.existsSync(BODY_PATH)) {
+  if (!fs.existsSync(INDEX_PATH)) {
     // Make it looks nice
     return res.end(`<!DOCTYPE html>
 <html>
@@ -148,44 +159,22 @@ See an example in the <a href="https://www.jest-preview.com/docs/getting-started
 <script>${reloadScriptContent}</script>
 </html>`);
   }
-  const head = fs.readFileSync(HEAD_PATH, 'utf8');
-  const body = fs.readFileSync(BODY_PATH, 'utf8');
-  // TODO2: How do we preserve the order of importing css file?
-  // For now I think it's not very important, but this is the room for improvement in next versions
-  let css = '';
-  // TODO: Do not need to construct css from files, since we can construct it from memory (client sends css files' location via websocket event)
-  const allFiles = fs.readdirSync(CACHE_DIRECTORY);
-  allFiles.forEach((file) => {
-    if (file.endsWith('.css')) {
-      css += `\n<style>${fs.readFileSync(
-        path.join(CACHE_DIRECTORY, path.basename(file)),
-        'utf8',
-      )}</style>`;
-    }
-  });
-
-  const htmlContent = `<!DOCTYPE html>
-<html>
-<head>
-  <link rel="shortcut icon" href="${FAV_ICON_PATH}">
+  let indexHtml = fs.readFileSync(INDEX_PATH, 'utf8');
+  indexHtml += `<script>${reloadScriptContent}</script>`;
+  indexHtml = injectToHead(
+    indexHtml,
+    `<link rel="shortcut icon" href="${FAV_ICON_PATH}">
   <title>Jest Preview Dashboard</title>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
-${css}
-${head}
-</head>
-<body>
-  ${body}
-</body>
-<script>${reloadScriptContent}</script>
-</html>`;
-  res.end(htmlContent);
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">`,
+  );
+  res.end(indexHtml);
 });
 
 const server = http.createServer(app);
 
 server.listen(port, () => {
-  if (fs.existsSync(BODY_PATH)) {
+  if (fs.existsSync(INDEX_PATH)) {
     // Remove old preview
     const files = fs.readdirSync(CACHE_DIRECTORY);
     files.forEach((file) => {

--- a/cli/server/vite.config.js
+++ b/cli/server/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig, loadEnv } from 'vite';
+
+export default defineConfig({
+  server: {
+    watch: {
+      ignored: ['!**/node_modules/.cache/jest-preview/**'],
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "@types/connect": "^3.4.35",
         "@types/react": "^17.0.33",
         "@types/react-dom": "^17.0.10",
         "@types/styled-components": "^5.1.24",
@@ -1728,6 +1729,15 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -10123,6 +10133,15 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
         "commander": "^9.2.0",
         "connect": "^3.7.0",
         "find-node-modules": "^2.1.3",
@@ -20,8 +19,7 @@
         "sirv": "^2.0.2",
         "slash": "^3.0.0",
         "string-hash": "^1.1.3",
-        "update-notifier": "^5.1.0",
-        "ws": "^8.5.0"
+        "update-notifier": "^5.1.0"
       },
       "bin": {
         "jest-preview": "cli/index.js"
@@ -2138,6 +2136,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2356,6 +2355,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2594,6 +2594,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3950,6 +3951,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4067,6 +4069,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4516,6 +4519,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6421,6 +6425,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7445,6 +7450,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -8808,26 +8814,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -10479,6 +10465,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -10641,7 +10628,8 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "boxen": {
       "version": "5.1.2",
@@ -10804,6 +10792,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -11754,6 +11743,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -11834,6 +11824,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -12178,6 +12169,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -13602,7 +13594,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -14319,6 +14312,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -15347,12 +15341,6 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
-    },
-    "ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "@types/connect": "^3.4.35",
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "@types/styled-components": "^5.1.24",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "camelcase": "^6.3.0",
     "chalk": "^4.1.2",
-    "chokidar": "^3.5.3",
     "commander": "^9.2.0",
     "connect": "^3.7.0",
     "find-node-modules": "^2.1.3",
@@ -66,8 +65,7 @@
     "sirv": "^2.0.2",
     "slash": "^3.0.0",
     "string-hash": "^1.1.3",
-    "update-notifier": "^5.1.0",
-    "ws": "^8.5.0"
+    "update-notifier": "^5.1.0"
   },
   "devDependencies": {
     "@emotion/react": "^11.9.0",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -2,19 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import { CACHE_FOLDER } from './constants';
 
-export function debug(element: Element = document.body): void {
+export function debug(): void {
   if (!fs.existsSync(CACHE_FOLDER)) {
     fs.mkdirSync(CACHE_FOLDER, {
       recursive: true,
     });
   }
 
-  const headChildrenOnly = Array.from(document.head.children).reduce(
-    (prev, current) => prev + current.outerHTML,
-    '',
+  fs.writeFileSync(
+    path.join(CACHE_FOLDER, 'index.html'),
+    document.documentElement.outerHTML,
   );
-  // TODO: Can we just use `document.documentElement.outerHTML` directly. Then, we don't need to save head and body separately.
-  fs.writeFileSync(path.join(CACHE_FOLDER, 'head.html'), headChildrenOnly);
-  // Always save head.html to disk before body.html, so we don't need to watch head.html
-  fs.writeFileSync(path.join(CACHE_FOLDER, 'body.html'), element.outerHTML);
 }


### PR DESCRIPTION
<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/X5PyPUfemh.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)
- Use `vite` for hot reload server instead of DIY

## Related issues

<!-- Add related issue here: E.g: #124-->

- #155
- Potentially #138

## Features

- [ ] Use vite internally instead of handling live update with websocket, chokidar
- [ ] Always preview the full document when running `preview.debug()`
