### PR TITLE
feat: Run cypress on documentation site periodically

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,15 @@
+name: End-to-end tests
+on:
+  schedule:
+    # Runs at 10h and 22h everyday
+    - cron: '0 10,22 * * *'
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Cypress
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: docs-e2e-testing


### PR DESCRIPTION
<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/X5PyPUfemh.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)

## Related issues

<!-- Add related issue here: E.g: #124-->

- #181 

## Features

- [x] Run cypress on documentation site periodically (2 times per day) using github action

