### PR TITLE
fix: Support es module for e2e test

### DIFF
--- a/docs-e2e-testing/package.json
+++ b/docs-e2e-testing/package.json
@@ -10,5 +10,6 @@
   "license": "MIT",
   "devDependencies": {
     "cypress": "^10.2.0"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/X5PyPUfemh.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)
- After merging PR #192, the workflow still failed because the e2e config file uses the es module, which is not supported in workflow environment

## Related issues

<!-- Add related issue here: E.g: #124-->

- #181 

## Fixes

- [x] Support es module for e2e test

