### PR TITLE
Fix issue not reload on Linux by always read html from `index.html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.8
+
+## Fixes
+
+- Fix bug Jest Preview Dashboard does not reload on Linux systems.
+
 # 0.2.7
 
 ## Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-preview",
-  "version": "0.2.7",
+  "version": "0.2.8-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-preview",
-      "version": "0.2.7",
+      "version": "0.2.8-alpha.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preview",
-  "version": "0.2.7",
+  "version": "0.2.8-alpha.0",
   "description": "Preview your Jest tests in a browser",
   "keywords": [
     "testing",

--- a/website/docs/others/faq.md
+++ b/website/docs/others/faq.md
@@ -24,4 +24,8 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 ## I couldn't use Automatic Mode
 
-Automatic Mode is in experiemental phase. If you are experiencing any issues when using Automatic Mode, please let us know at [Jest Preview's GitHub issue](https://github.com/nvh95/jest-preview/issues/new?assignees=&labels=&template=bug_report.md&title=). We appreciate your feedback and it would be super helpful for us to have a reproducible repository.
+Automatic Mode is in the experimental phase. If you are experiencing any issues when using Automatic Mode, please let us know at [Jest Preview's GitHub issue](https://github.com/nvh95/jest-preview/issues/new?assignees=&labels=&template=bug_report.md&title=). We appreciate your feedback and it would be super helpful for us to have a reproducible repository.
+
+## The preview does not reload automatically
+
+This is likely that you are using a Linux system. Please update [jest-preview](https://www.npmjs.com/package/jest-preview) to the newest version (`>= 0.2.8`) to get the problem fixed. If it still persists, please help to [report a bug](https://github.com/nvh95/jest-preview/issues/new?assignees=&labels=bug&template=bug_report.md&title=) with a minimum reproduction.


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)
- Preview page doesn't automatically reload after running tests
- Possible root cause: https://github.com/nvh95/jest-preview/pull/199#issuecomment-1186088862

## Related issues

<!-- Add related issue here: E.g: #124-->
- #138 

## Fixes
- [x] Fix Jest Preview Dashboard does not reload automatically
  - Move "clear cache" code out of `server.listen` callback
  - Always write `index.html` to make sure it's always existed
  - Do not generate "blank page" on demand (`app.use('/')`), instead, write to disk at **2.**
- [x] (As a result), the [online demo](https://stackblitz.com/edit/jest-preview?file=README.md) is fixed

*We also tried another approach here (generate a new file name for index.html each time the server starts), we can keep this as a reference https://github.com/nvh95/jest-preview/pull/199*

