### PR TITLE
Ability to put `debug()` in multiple test cases

### DIFF
--- a/cli/server/previewServer.js
+++ b/cli/server/previewServer.js
@@ -20,7 +20,11 @@ const INDEX_BASENAME = 'index.html';
 const INDEX_PATH = path.join(CACHE_DIRECTORY, INDEX_BASENAME);
 const PUBLIC_CONFIG_BASENAME = 'cache-public.config';
 const PUBLIC_CONFIG_PATH = path.join(CACHE_DIRECTORY, PUBLIC_CONFIG_BASENAME);
-const FAV_ICON_PATH = './node_modules/jest-preview/cli/server/favicon.ico';
+let FAV_ICON_PATH = './node_modules/jest-preview/cli/server/favicon.ico';
+if (!fs.existsSync(FAV_ICON_PATH)) {
+  // For dev purpose only
+  FAV_ICON_PATH = './cli/server/favicon.ico';
+}
 
 // Always set default public folder to `public` if not specified
 let publicFolder = 'public';

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { exec } from 'child_process';
 import chalk from 'chalk';
-import { CACHE_FOLDER, SASS_LOAD_PATHS_CONFIG } from './constants';
+import { CACHE_FOLDER, DELIMITER, SASS_LOAD_PATHS_CONFIG } from './constants';
 import { createCacheFolderIfNeeded } from './utils';
 import { debug } from './preview';
 
@@ -61,8 +61,7 @@ export function jestPreviewConfigure(
         'See the migration guide at www.jest-preview.com/blog/deprecate-externalCss',
       ),
     );
-    const delimiter = '___';
-    const destinationBasename = `cache-${cssFile.replace(/\//g, delimiter)}`;
+    const destinationBasename = `cache-${cssFile.replace(/\//g, DELIMITER)}`;
     const destinationFile = path.join(CACHE_FOLDER, destinationBasename);
 
     createCacheFolderIfNeeded();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const CACHE_FOLDER = './node_modules/.cache/jest-preview';
 export const SASS_LOAD_PATHS_CONFIG = 'cache-sass-load-paths.config';
+export const DELIMITER = '_____';

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,14 +1,35 @@
 import fs from 'fs';
 import path from 'path';
-import { CACHE_FOLDER } from './constants';
+import { CACHE_FOLDER, DELIMITER } from './constants';
+import crypto from 'crypto';
 
+// TODO: Add debug() result to /preview folder
+// TODO: Add debug() result of failed test in /failed folder
 export function debug(): void {
-  if (!fs.existsSync(CACHE_FOLDER)) {
-    fs.mkdirSync(CACHE_FOLDER, {
+  const { testPath, currentTestName } = expect.getState();
+  const testIdentification = [testPath, currentTestName].join(DELIMITER);
+  const folderNameHash = crypto
+    .createHash('md5')
+    .update(testIdentification)
+    .digest('hex');
+
+  const folderPath = path.join(CACHE_FOLDER, 'preview', folderNameHash);
+  if (!fs.existsSync(folderPath)) {
+    fs.mkdirSync(folderPath, {
       recursive: true,
     });
   }
 
+  // Save each `debug()` to a different folder
+  fs.writeFileSync(
+    path.join(folderPath, 'index.html'),
+    document.documentElement.outerHTML,
+  );
+
+  // To retrieve testPath, currentTestName
+  fs.writeFileSync(path.join(folderPath, 'info.txt'), testIdentification);
+
+  // Still write current screenshot
   fs.writeFileSync(
     path.join(CACHE_FOLDER, 'index.html'),
     document.documentElement.outerHTML,


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

Now `debug()` is useful when we focus on one test. If users put `debug()` in multiple test cases, there will be conflicts


## Related issues

<!-- Add related issue here: E.g: #124-->

- #21

## Features


- [ ] Allow user to use `debug()` in multiple test case (`/preview`)
- [ ] Allow user to see failed tests after running all the tests (maybe `/failed`)

## Screenshots
![/preview at main](https://user-images.githubusercontent.com/8603085/180469322-272e5623-8204-4875-b353-163efe153aa6.png)
![/preview route](https://user-images.githubusercontent.com/8603085/180469333-cb3387d1-c1ba-4b63-9da9-a5551de5c520.png)
![one snapshot](https://user-images.githubusercontent.com/8603085/180469342-cc3d3576-4357-4a76-a4c9-11ec765bee8d.png)

## Pending issues/ Need discussions

- [ ] We need to come up with a better UX
  - [ ] `/preview` does not reloads yet
  - [ ] `/preview/hash_id` does not reload yet
  - [ ] We might use React/ Vue/ Svelte to construct the UI easier
  - [ ] (Need investigation) It looks like it's easier if we use Vite internally instead of DIY #184 