### PR TITLE
docs: correct installation step count

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -92,7 +92,7 @@ Below you can find a list of public directories which have different names than 
 | [Angular](https://angular.io/)       | `src`            |
 | [Preact](https://preactjs.com)       | `src/static`     |
 
-### 5. (Optional- RECOMMENDED) Opt-in to Automatic Mode
+### 6. (Optional- RECOMMENDED) Opt-in to Automatic Mode
 
 **Automatic Mode** let you use [jest-preview](https://www.npmjs.com/package/jest-preview) without manually triggering `preview.debug()`. It previews your code in the browser automatically whenever there is a failed test. It's a experimental feature from v0.2.0 and becomes the default in v0.3.0.
 


### PR DESCRIPTION
The step count of step 6 was marked as a duplicate step 5.

<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/z4DRBmk7vx.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)
I followed the installation guide and noticed two step 5s.

## Related issues

<!-- Add related issue here: E.g: #124-->

- N/A

## Documentation
- [x] Correct step count in the installation guide
