### PR TITLE
Fix link typo in nextjs example README

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates how to use `jest-preview` with `Next.js`, bootstrapped using `create-next-app`.
 
-⚠️ This example is meant for Next.js apps using the new [Next.js compiler](https://nextjs.org/docs/advanced-features/compiler) (also called Rust compiler), available from Next.js 12.0.0 onward. If you use Next.js version 11 or below, or opt-out of the Next.js compiler, please see the [nextjs-babel](https://www.jest-preview.com/docs/examples/next-babel) example.
+⚠️ This example is meant for Next.js apps using the new [Next.js compiler](https://nextjs.org/docs/advanced-features/compiler) (also called Rust compiler), available from Next.js 12.0.0 onward. If you use Next.js version 11 or below, or opt-out of the Next.js compiler, please see the [nextjs-babel](https://www.jest-preview.com/docs/examples/nextjs-babel) example.
 
 🚧 Next.js's `<Image />` component isn't working with Jest Preview yet.
 


### PR DESCRIPTION


<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/z4DRBmk7vx.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)

Previous link went to a 404 page in the nextjs example readme

## Related issues

<!-- Add related issue here: E.g: #124-->

- None

## Fixes

- [x] Typo in next js readme doc
