### PR TITLE
fix: Use hostname instead of localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.2
+
+## Fixes
+
+- Support run `jest-preview` on remote server
+
 # 0.3.1
 
 ## Features

--- a/cli/server/ws-client.js
+++ b/cli/server/ws-client.js
@@ -1,7 +1,7 @@
 // PORT is replaced by `jest-dom` server
 const port = '$PORT';
 
-const socket = new WebSocket(`ws://localhost:${port}`);
+const socket = new WebSocket(`ws://${window.location.hostname}:${port}`);
 
 socket.addEventListener('message', async ({ data }) => {
   // handleMessage(JSON.parse(data))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preview",
-  "version": "0.3.1",
+  "version": "0.3.2-alpha.0",
   "description": "Preview your Jest tests in a browser",
   "keywords": [
     "testing",


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

## Related issues

<!-- Add related issue here: E.g: #124-->

- #258

## Fixes

- [x] Support run `jest-preview` on a remote server
