### PR TITLE
docs(website): initialize i18n

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -94,6 +94,10 @@ const config = {
             label: 'Discord',
             position: 'right',
           },
+          {
+            type: 'localeDropdown',
+            position: 'right',
+          },
         ],
       },
       footer: {
@@ -164,6 +168,10 @@ const config = {
         indexName: 'jest-preview',
       },
     }),
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'vi-VN', 'zh-CN'],
+  },
 };
 
 module.exports = config;

--- a/website/i18n/vi-VN/code.json
+++ b/website/i18n/vi-VN/code.json
@@ -1,0 +1,447 @@
+{
+  "home.header.subtitle": {
+    "message": "Debug your Jest tests. Effortlessly. 🛠🖼"
+  },
+  "home.header.get-started": {
+    "message": "Get Started"
+  },
+  "home.header.try-now": {
+    "message": "Try now"
+  },
+  "home.sponsors.heading": {
+    "message": "Sponsors"
+  },
+  "home.sponsors.description": {
+    "message": "Support on {openCollectiveLink}, starting from {oneDollar}"
+  },
+  "home.sponsors.want": {
+    "message": "Want your company logo appear here? Read more at {sponsorsLink}."
+  },
+  "home.sponsors.want.sponsors-link": {
+    "message": "Sponsors"
+  },
+  "home.featureList.dx-driven.title": {
+    "message": "DX-Driven"
+  },
+  "home.featureList.dx-driven.description": {
+    "message": "Jest Preview has a mission: To make front end developers' life easier. It's built with the mindset of {dx} first in mind."
+  },
+  "home.featureList.dx-driven.description.dx": {
+    "message": "Developer Experience"
+  },
+  "home.featureList.fast.title": {
+    "message": "Fast"
+  },
+  "home.featureList.fast.description": {
+    "message": "Write tests in Jest and see the changes reflects in browser in {ms}"
+  },
+  "home.featureList.fast.description.ms": {
+    "message": "a few milliseconds",
+    "description": "a few milliseconds"
+  },
+  "home.featureList.framework-agnostic.title": {
+    "message": "Framework-Agnostic"
+  },
+  "home.featureList.framework-agnostic.description": {
+    "message": "You can use Jest Preview with {tl} and {ff}."
+  },
+  "home.featureList.framework-agnostic.description.tl": {
+    "message": "any testing libraries",
+    "description": "any testing libraries"
+  },
+  "home.featureList.framework-agnostic.description.ff": {
+    "message": "frontend frameworks",
+    "description": "frontend frameworks"
+  },
+  "home.featureList.productivity.title": {
+    "message": "Productivity"
+  },
+  "home.featureList.productivity.description": {
+    "message": "Don't waste time guessing what is your UI looks like. Let's Jest Preview {visualize} it in a browser for you!"
+  },
+  "home.featureList.productivity.description.visualize": {
+    "message": "visualize"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "Trang này đã bị lỗi.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Thử lại",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Không tìm thấy trang",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "Chúng tôi không thể tìm thấy những gì bạn đang tìm kiếm.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Vui lòng liên hệ với trang web đã dẫn bạn tới đây và thông báo cho họ biết rằng đường dẫn này bị hỏng.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Đóng",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.note": {
+    "message": "ghi chú",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "mẹo",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "cảnh báo",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "thông tin",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "cẩn thận",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Trở lại đầu trang",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Thanh điều hướng của trang danh sách bài viết",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Các bài mới hơn",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Các bài cũ hơn",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.archive.title": {
+    "message": "Lưu trữ",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Lưu trữ",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Thanh điều hướng của trang bài viết",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Bài mới hơn",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Bài cũ hơn",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Một bài viết|{count} bài viết",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} được gắn thẻ \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Xem tất cả Thẻ",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Chuyển đổi chế độ sáng và tối (hiện tại {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "chế độ tối",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "chế độ sáng",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Trang chủ",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} mục",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Thanh điều hướng của trang tài liệu",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Trước",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Kế tiếp",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Một tài liệu đã gắn thẻ|{count} tài liệu đã gắn thẻ",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} với \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Phiên bản: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Đây là tài liệu chưa được phát hành chính thức của {siteTitle} phiên bản {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Đây là tài liệu của {siteTitle} {versionLabel}, hiện không còn được bảo trì.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Để xem các cập nhật mới nhất, vui lòng xem phiên bản {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "phiên bản mới nhất",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Sửa trang này",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Đường dẫn trực tiếp tới đề mục này",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " vào {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " bởi {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Cập nhật lần cuối {atDate} bởi {byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Phiên bản",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Nhảy tới nội dung",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Thẻ:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Điều hướng các bài viết gần đây trên blog",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Đã sao chép",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Sao chép code vào bộ nhớ tạm",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Sao chép",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Chuyển đổi văn bản xuống dòng",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Chuyển đổi danh mục thanh bên có thể thu gọn '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Trên trang này",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Ngôn ngữ",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Đọc tiếp",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Đọc thêm về {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Một phút để đọc|{readingTime} phút để đọc",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Thu gọn thanh bên",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Thu gọn thanh bên",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Trở lại menu chính",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Mở rộng thanh bên",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Mở rộng thanh bên",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "Xem tất cả {count} kết quả"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "Tìm thấy một kết quả|Tìm thấy {count} kết quả",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Kết quả tìm kiếm cho \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Tìm kiếm",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Nhập từ khóa cần tìm vào đây",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Tìm kiếm",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Tìm kiếm với Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "Không tìm thấy kết quả nào",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Đang tải thêm kết quả...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Tìm kiếm",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  }
+}

--- a/website/i18n/vi-VN/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/vi-VN/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "All posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/vi-VN/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/vi-VN/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,26 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Advanced Guides": {
+    "message": "Advanced Guides",
+    "description": "The label for category Advanced Guides in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Examples": {
+    "message": "Examples",
+    "description": "The label for category Examples in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Others": {
+    "message": "Others",
+    "description": "The label for category Others in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.API Reference": {
+    "message": "API Reference",
+    "description": "The label for category API Reference in sidebar tutorialSidebar"
+  }
+}

--- a/website/i18n/vi-VN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/vi-VN/docusaurus-theme-classic/footer.json
@@ -1,0 +1,42 @@
+{
+  "link.title.Docs": {
+    "message": "Docs",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "Community",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Tutorial": {
+    "message": "Tutorial",
+    "description": "The label of footer link with label=Tutorial linking to /docs/getting-started/intro"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/JestPreview"
+  },
+  "link.item.label.Hung's Twitter": {
+    "message": "Hung's Twitter",
+    "description": "The label of footer link with label=Hung's Twitter linking to https://twitter.com/hung_dev"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/z4DRBmk7vx"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/nvh95/jest-preview"
+  },
+  "copyright": {
+    "message": "Copyright © 2022 Hung Viet Nguyen. Built with Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/vi-VN/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/vi-VN/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "message": "Jest Preview",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.Demo": {
+    "message": "Demo",
+    "description": "Navbar item with label Demo"
+  },
+  "item.label.Feedback": {
+    "message": "Feedback",
+    "description": "Navbar item with label Feedback"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.npm": {
+    "message": "npm",
+    "description": "Navbar item with label npm"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  }
+}

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -1,0 +1,447 @@
+{
+  "home.header.subtitle": {
+    "message": "轻松调试您的 Jest 测试 🛠🖼"
+  },
+  "home.header.get-started": {
+    "message": "入门"
+  },
+  "home.header.try-now": {
+    "message": "立即尝试"
+  },
+  "home.featureList.dx-driven.title": {
+    "message": "DX驱动"
+  },
+  "home.featureList.dx-driven.description": {
+    "message": "Jest Preview 让开发者更轻松，它的构建优先考虑{dx}"
+  },
+  "home.featureList.dx-driven.description.dx": {
+    "message": "开发者体验"
+  },
+  "home.featureList.fast.title": {
+    "message": "极速体验"
+  },
+  "home.featureList.fast.description": {
+    "message": "在Jest中编写测试并在{ms}于浏览器中发现变化"
+  },
+  "home.featureList.fast.description.ms": {
+    "message": "毫秒内",
+    "description": "a few milliseconds"
+  },
+  "home.featureList.framework-agnostic.title": {
+    "message": "框架广泛"
+  },
+  "home.featureList.framework-agnostic.description": {
+    "message": "你可以在{tl}和{ff}中使用Jest Preview"
+  },
+  "home.featureList.framework-agnostic.description.tl": {
+    "message": "任何测试库",
+    "description": "any testing libraries"
+  },
+  "home.featureList.framework-agnostic.description.ff": {
+    "message": "前端框架",
+    "description": "frontend frameworks"
+  },
+  "home.featureList.productivity.title": {
+    "message": "提高生产力"
+  },
+  "home.featureList.productivity.description": {
+    "message": "不用再花费时间猜测你的UI是什么样了。 让 Jest Preview 在浏览器中实现{visualize}吧！"
+  },
+  "home.featureList.productivity.description.visualize": {
+    "message": "可视化"
+  },
+  "home.sponsors.heading": {
+    "message": "赞助商"
+  },
+  "home.sponsors.description": {
+    "message": "欢迎在 {openCollectiveLink} 赞助我们，从 {oneDollar} 开始吧！"
+  },
+  "home.sponsors.want": {
+    "message": "想让您的公司标志出现在这里吗？{sponsorsLink}了解详情"
+  },
+  "home.sponsors.want.sponsors-link": {
+    "message": "在此"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "页面已崩溃。",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "重试",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "我们找不到您要找的页面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "备注",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "危险",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "信息",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.archive.title": {
+    "message": "历史博文",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "历史博文",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分页导航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "较新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "较旧的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "博文分页导航",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "较新一篇",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "较旧一篇",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} 篇博文",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} 含有标签「{tagName}」",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "查看所有标签",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "切换浅色/暗黑模式（当前为{mode}）",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "暗黑模式",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "浅色模式",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "主页面",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "页面路径",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} 个项目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "文档分页导航",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "上一页",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "下一页",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count} 篇文档带有标签",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged}「{tagName}」",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版的文档，现已不再积极维护。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新的文档请参阅 {latestVersionLink} ({versionLabel})。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新版本",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "编辑此页",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "标题的直接链接",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "于 {date} ",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "由 {user} ",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "最后{byUser}{atDate}更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "选择版本",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "跳到主要内容",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "标签：",
+    "description": "The label alongside a tag list"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "最近博文导航",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "复制成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "复制代码到剪贴板",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "复制",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "切换自动换行",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "打开/收起侧边栏菜单「{label}」",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "本页总览",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "选择语言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readMore": {
+    "message": "阅读更多",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "阅读 {title} 的全文",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主菜单",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部 {count} 个结果"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "找到 {count} 份文件",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "「{query}」的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "在文档中搜索",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "在此输入搜索字词",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "搜索",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "通过 Algolia 搜索",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "未找到任何结果",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "正在获取新的搜索结果...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜索",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "清除查询",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "取消",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "最近搜索",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "没有最近搜索",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "保存这个搜索",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "从历史记录中删除这个搜索",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "收藏",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "从收藏列表中删除这个搜索",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "无法获取结果",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "你可能需要检查网络连接。",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "选中",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter 键",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "导航",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "向上键",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "向下键",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "关闭",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Esc 键",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "搜索提供",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "没有结果：",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "试试搜索",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "认为这个查询应该有结果？",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "请告知我们。",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "搜索文档",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "All posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,26 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Getting Started": {
+    "message": "入门",
+    "description": "The label for category Getting Started in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Advanced Guides": {
+    "message": "高级指南",
+    "description": "The label for category Advanced Guides in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Examples": {
+    "message": "用例",
+    "description": "The label for category Examples in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Others": {
+    "message": "其它",
+    "description": "The label for category Others in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.API Reference": {
+    "message": "API 参考",
+    "description": "The label for category API Reference in sidebar tutorialSidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/intro.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/intro.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 1
+description: 当使用Jest编写测试时，我们通常通过阅读HTML代码进行调试。有时HTML太复杂了，Jest Preview 帮助您在浏览器中“看见”您的测试。
+---
+
+# 介绍
+
+## 认识 Jest Preview
+
+我们相信您已经厌倦了调试集成 UI 测试和阅读一大堆隐晦的 HTML 输出。要将 DOM 结构可视化，并发现那里出了问题以及为什么出了问题，这实在是相当困难。我们感同身受。这就是为什么我们创建了 Jest Preview！
+
+Jest Preview 是一个开源库使您的测试更轻松。它可以让您直接在浏览器中看到测试输出，就像您平时看您在做的应用程序一样。编写测试并观察渲染输出的相应变化，Jest Preview 让你专注于“真正的”的测试，而不是破译 HTML 代码。听起来是不是很有趣？快来试试吧 😉
+
+👇 继续阅读以了解更多信息并尝试 Jest Preview 的操作
+
+:::info
+您可以直接前往 [安装](https://www.jest-preview.com/docs/getting-started/installation) 指南，并在本地安装它
+:::
+
+## 特性
+
+- 🐣 它的安装和使用都非常简单！
+- 👀 在浏览器中以毫秒级的速度预览你的实际应用的 HTML
+- 🔄 自动刷新浏览器当执行 `preview.debug()`
+- 💅 支持 CSS：
+  - ✅ [Direct CSS import](#3-configure-jests-transform-to-intercept-css-and-files)
+  - ✅ 相对多的 CSS-in-JS 库，例如：
+    - ✅ [Styled-components](https://styled-components.com/)
+    - ✅ [Emotion](https://emotion.sh/)
+  - ✅ [Global CSS](/docs/getting-started/installation#4-optional-configure-global-css)
+  - ✅ [CSS Modules](https://github.com/css-modules/css-modules)
+  - ✅ [Sass](https://sass-lang.com/)
+- 🌄 支持查看图片
+- 🧑‍💻 我们的贡献者正努力增加更多功能并提供支持 ⚙️
+
+:::info
+愿意参与贡献吗？太棒了！我们非常感谢！请查看 [贡献](/docs/others/contributing) 文档 🙏
+:::
+
+## 在线 Demo
+
+想要在安装前尝试一下这个库吗？我们为您准备好了！前往 [StackBlitz Demo App](https://stackblitz.com/edit/jest-preview?embed=1&file=README.md) 或在此尝试 😉
+
+[![](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/edit/jest-preview?file=src%2FApp.test.tsx,README.md)
+
+<iframe id="iframe" height="600px" width="100%" style={{marginBottom: "24px" }} src="https://stackblitz.com/edit/jest-preview?embed=1&ctl=1&file=src%2FApp.test.tsx,README.md"></iframe>
+
+:::tip 与框架无关
+**Jest Preview** 最初是为了与 [jest](https://jestjs.io/) 和 [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/) 一起使用。这个库与框架无关，你可以将其与**任何**测试库使用
+:::
+
+## 如何只用两行代码使用 Jest Preview
+
+通过运行 CLI 命令 `jest-preview` 来启动 Jest Preview 本地服务器。更好的教程请参考 [安装](https://www.jest-preview.com/docs/getting-started/installation) 指南
+
+```diff
++import preview from 'jest-preview';
+
+describe('App', () => {
+  it('should work as expected', () => {
+    render(<App />);
++    preview.debug();
+  });
+});
+```
+
+或：
+
+```diff
++import { debug } from 'jest-preview';
+
+describe('App', () => {
+  it('should work as expected', () => {
+    render(<App />);
++    debug();
+  });
+});
+```
+
+:::tip 就是这么简单！😱
+:::

--- a/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -1,0 +1,42 @@
+{
+  "link.title.Docs": {
+    "message": "文档",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "社区",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "更多",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Tutorial": {
+    "message": "教程",
+    "description": "The label of footer link with label=Tutorial linking to /docs/getting-started/intro"
+  },
+  "link.item.label.Blog": {
+    "message": "博客",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/JestPreview"
+  },
+  "link.item.label.Hung's Twitter": {
+    "message": "Hung's Twitter",
+    "description": "The label of footer link with label=Hung's Twitter linking to https://twitter.com/hung_dev"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/z4DRBmk7vx"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/nvh95/jest-preview"
+  },
+  "copyright": {
+    "message": "Copyright © 2022 Hung Viet Nguyen. Built with Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "message": "Jest Preview",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "文档",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blog": {
+    "message": "博客",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.Demo": {
+    "message": "Demo",
+    "description": "Navbar item with label Demo"
+  },
+  "item.label.Feedback": {
+    "message": "反馈",
+    "description": "Navbar item with label Feedback"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.npm": {
+    "message": "npm",
+    "description": "Navbar item with label npm"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  }
+}

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
+import Translate, { translate } from '@docusaurus/Translate';
 
 type FeatureItem = {
   title: string;
@@ -8,46 +9,120 @@ type FeatureItem = {
   description: JSX.Element;
 };
 
+// FIXME The SVG here (or all static files) cannot be loaded in i18n dev mode
 const FeatureList: FeatureItem[] = [
   {
-    title: 'DX-Driven',
+    title: translate({
+      id: 'home.featureList.dx-driven.title',
+      message: 'DX-Driven',
+    }),
     Svg: '/img/dx.svg',
     description: (
-      <>
-        Jest Preview has a mission: To make front end developers' life easier.
-        It's built with the mindset of <strong>Developer Experience</strong>{' '}
-        first in mind.
-      </>
+      <Translate
+        id="home.featureList.dx-driven.description"
+        values={{
+          dx: (
+            <strong>
+              <Translate id="home.featureList.dx-driven.description.dx">
+                Developer Experience
+              </Translate>
+            </strong>
+          ),
+        }}
+      >
+        {
+          "Jest Preview has a mission: To make front end developers' life easier. It's built with the mindset of {dx} first in mind."
+        }
+      </Translate>
     ),
   },
   {
-    title: 'Fast',
+    title: translate({
+      id: 'home.featureList.fast.title',
+      message: 'Fast',
+    }),
     Svg: '/img/fast.svg',
     description: (
-      <>
-        Write tests in Jest and see the changes reflects in browser in{' '}
-        <strong>a few milliseconds</strong>.
-      </>
+      <Translate
+        id="home.featureList.fast.description"
+        values={{
+          ms: (
+            <strong>
+              <Translate
+                id="home.featureList.fast.description.ms"
+                description="a few milliseconds"
+              >
+                a few milliseconds
+              </Translate>
+            </strong>
+          ),
+        }}
+      >
+        {'Write tests in Jest and see the changes reflects in browser in {ms}'}
+      </Translate>
     ),
   },
 
   {
-    title: 'Framework-Agnostic',
+    title: translate({
+      id: 'home.featureList.framework-agnostic.title',
+      message: 'Framework-Agnostic',
+    }),
     Svg: '/img/agnostic.svg',
     description: (
-      <>
-        You can use Jest Preview with <strong>any testing libraries</strong> and{' '}
-        <strong>frontend frameworks</strong>.
-      </>
+      <Translate
+        id="home.featureList.framework-agnostic.description"
+        values={{
+          tl: (
+            <strong>
+              <Translate
+                id="home.featureList.framework-agnostic.description.tl"
+                description="any testing libraries"
+              >
+                any testing libraries
+              </Translate>
+            </strong>
+          ),
+          ff: (
+            <strong>
+              <Translate
+                id="home.featureList.framework-agnostic.description.ff"
+                description="frontend frameworks"
+              >
+                frontend frameworks
+              </Translate>
+            </strong>
+          ),
+        }}
+      >
+        {'You can use Jest Preview with {tl} and {ff}.'}
+      </Translate>
     ),
   },
   {
-    title: 'Productivity',
+    title: translate({
+      id: 'home.featureList.productivity.title',
+      message: 'Productivity',
+    }),
     Svg: '/img/productivity.svg',
     description: (
       <>
-        Don't waste time guessing what is your UI looks like. Let's Jest Preview{' '}
-        <strong>visualize</strong> it in a browser for you!
+        <Translate
+          id="home.featureList.productivity.description"
+          values={{
+            visualize: (
+              <strong>
+                <Translate id="home.featureList.productivity.description.visualize">
+                  visualize
+                </Translate>
+              </strong>
+            ),
+          }}
+        >
+          {
+            "Don't waste time guessing what is your UI looks like. Let's Jest Preview {visualize} it in a browser for you!"
+          }
+        </Translate>
       </>
     ),
   },

--- a/website/src/components/Sponsors/index.tsx
+++ b/website/src/components/Sponsors/index.tsx
@@ -1,3 +1,4 @@
+import Translate, { translate } from '@docusaurus/Translate';
 import React from 'react';
 import styles from './styles.module.css';
 
@@ -6,19 +7,29 @@ export default function Sponsors() {
     <div className={styles.wrapper}>
       <div className="row">
         <div className="col">
-          <h2 className={styles.sponsorsHeading}>Sponsors</h2>
+          <h2 className={styles.sponsorsHeading}>
+            {translate({ id: 'home.sponsors.heading', message: 'Sponsors' })}
+          </h2>
         </div>
       </div>
       <div className={styles.description}>
-        Support on{' '}
-        <a
-          href="https://opencollective.com/jest-preview"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Translate
+          id="home.sponsors.description"
+          values={{
+            openCollectiveLink: (
+              <a
+                href="https://opencollective.com/jest-preview"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open Collective
+              </a>
+            ),
+            oneDollar: <strong>$1</strong>,
+          }}
         >
-          Open Collective
-        </a>
-        , starting from <b>$1</b>.
+          {'Support on {openCollectiveLink}, starting from {oneDollar}'}
+        </Translate>
       </div>
       <div className="row">
         <div className="col">
@@ -45,15 +56,24 @@ export default function Sponsors() {
         </a>
       </div>
       <div className={styles.wantLogo}>
-        Want your company logo appear here? Read more at{' '}
-        <a
-          href="https://github.com/nvh95/jest-preview#sponsors"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Translate
+          id="home.sponsors.want"
+          values={{
+            sponsorsLink: (
+              <a
+                href="https://github.com/nvh95/jest-preview#sponsors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Translate id="home.sponsors.want.sponsors-link">
+                  Sponsors
+                </Translate>
+              </a>
+            ),
+          }}
         >
-          Sponsors
-        </a>
-        .
+          {'Want your company logo appear here? Read more at {sponsorsLink}.'}
+        </Translate>
       </div>
     </div>
   );

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -7,6 +7,7 @@ import styles from './index.module.css';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Sponsors from '@site/src/components/Sponsors';
 import Carbon from '../components/Carbon';
+import { translate } from '@docusaurus/Translate';
 
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
@@ -14,13 +15,21 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className="hero__subtitle">
+          {translate({
+            id: 'home.header.subtitle',
+            message: 'Debug your Jest tests. Effortlessly. 🛠🖼',
+          })}
+        </p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
             to="/docs/getting-started/intro"
           >
-            Get Started
+            {translate({
+              id: 'home.header.get-started',
+              message: 'Get Started',
+            })}
           </Link>
           <a
             href="https://stackblitz.com/edit/jest-preview?file=src%2FApp.test.tsx,README.md"
@@ -28,7 +37,10 @@ function HomepageHeader() {
             rel="noopener noreferrer"
             className="button button--info button--lg"
           >
-            Try now
+            {translate({
+              id: 'home.header.try-now',
+              message: 'Try now',
+            })}
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

Initialize i18n for docusaurus docs. Add a little bit Chinese translation (for homepage and Introduction docs).

## Problem

~~The SVG (or all static files) cannot be loaded in i18n dev mode~~
Oh it works fine on production. That's good xD

https://github.com/jsun969/jest-preview/blob/c64240c4801844663d84fc637a4d71bf0067d631/website/src/components/HomepageFeatures/index.tsx#L12

## How to add Vietnamese translation

### For homepage

Modify `/website/i18n/vi-VN/code.json` Line2-Line64 (where id start with `home.`)

### For footer and navbar

Modify files in `/website/i18n/vi-VN/docusaurus-theme-classic`

### For docs

Modify `/website/i18n/vi-VN/docusaurus-plugin-content-docs/current.json` for directory  
Then see [i18n - Tutorial | Docusaurus #translate-markdown-files](https://docusaurus.io/docs/i18n/tutorial#translate-markdown-files)

## Notice

The `tagline` in docusaurus config is no longer used for homepage subtitle.


