### PR TITLE
feat: allow debug receive outerHTML

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { CACHE_FOLDER } from './constants';
 
-export function debug(): void {
+export function debug(outerHTML = document.documentElement.outerHTML): void {
   if (!fs.existsSync(CACHE_FOLDER)) {
     fs.mkdirSync(CACHE_FOLDER, {
       recursive: true,
@@ -11,6 +11,6 @@ export function debug(): void {
 
   fs.writeFileSync(
     path.join(CACHE_FOLDER, 'index.html'),
-    document.documentElement.outerHTML,
+    outerHTML,
   );
 }


### PR DESCRIPTION
## Summary/Motivation (TLDR;)

This PR adds a new feature to the Jest Preview library that allows developers to pass HTML output generated by other libraries to the `debug` function. Specifically, this PR replaces the current implementation of the `debug` function in `/src/preview.ts` with a new function that accepts an HTML string as a parameter. This makes it possible for developers to use other libraries (such as [react-native-to-jest-preview](https://github.com/antoniel/react-native-to-jest-preview)) to generate the HTML output for Jest Preview.

## Related issues

- #290 

## Features

- Allow the `debug` function to accept an HTML string generated by other libraries
- Replace the `debug` function in `/src/preview.ts` with a new implementation that accepts an HTML string parameter

## Fixes

- N/A

## Chores

- N/A

## Changes Made

This PR modifies the `/src/preview.ts` file to add support for passing an HTML string to the `debug` function. Specifically, the `debug` function has been replaced with a new function that accepts an `outerHTML` parameter. If the parameter is not provided, the function falls back to the previous behavior of using `document.documentElement.outerHTML`.

Here is the specific change that was made:

```diff
- export function debug(): void {
+ export function debug(outerHTML = document.documentElement.outerHTML): void {
    if (!fs.existsSync(CACHE_FOLDER)) {
      fs.mkdirSync(CACHE_FOLDER, {
        recursive: true,
      });
    }

    fs.writeFileSync(
      path.join(CACHE_FOLDER, 'index.html'),
-     document.documentElement.outerHTML,
+     outerHTML,
    );
  }
