### PR TITLE
Use update-notifier lib with dynamic import

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,4 @@
 import { program } from 'commander';
-import updateNotifier from 'update-notifier';
 import chalk from 'chalk';
 
 program
@@ -22,22 +21,24 @@ program.description('Start Jest Preview server.').action(() => {
 
 program.parse(process.argv);
 
-// Checks for available update and notify user
-const notifier = updateNotifier({
-    // Built output is at /cli so the relative path is ../package.json
-  pkg: require('../../package.json'),
-  updateCheckInterval: 0, // How often to check for updates
-  shouldNotifyInNpmScript: true, // Allows notification to be shown when running as an npm script
-  distTag: 'latest', // Can be use to notify user about pre-relase version
-});
+import('update-notifier').then(({ default: updateNotifier }) => {
+  // Checks for available update and notify user
+  const notifier = updateNotifier({
+      // Built output is at /cli so the relative path is ../package.json
+    pkg: require('../../package.json'),
+    updateCheckInterval: 0, // How often to check for updates
+    shouldNotifyInNpmScript: true, // Allows notification to be shown when running as an npm script
+    distTag: 'latest', // Can be use to notify user about pre-relase version
+  });
 
-notifier.notify({
-  defer: true, // Try not to annoy user by showing the notification after the process has exited
-  message: [
-    `${chalk.blue('{packageName}')} has an update available: ${chalk.gray(
-      '{currentVersion}',
-    )} → ${chalk.green('{latestVersion}')}`,
-    `Please run ${chalk.cyan('`{updateCommand}`')} to update.`,
-  ].join('\n'),
+  notifier.notify({
+    defer: true, // Try not to annoy user by showing the notification after the process has exited
+    message: [
+      `${chalk.blue('{packageName}')} has an update available: ${chalk.gray(
+        '{currentVersion}',
+      )} → ${chalk.green('{latestVersion}')}`,
+      `Please run ${chalk.cyan('`{updateCommand}`')} to update.`,
+    ].join('\n'),
+  });
+  // END checks for available update and notify user
 });
-// END checks for available update and notify user


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

Potential solution for the open #276 🐛

When trying to use the latest prerelease version that has update-notifier@6 installed I get the following error:
```
/jest-preview/dist/cli/index.js:5
var updateNotifier = require('update-notifier');
                     ^

Error [ERR_REQUIRE_ESM]: require() of ES Module ...
```

Inspiration comes from the Please [read this](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) section's choice num. 2 of the [update-notifier@6.0.0](https://github.com/yeoman/update-notifier/releases/tag/v6.0.0) release.

> 2. If the package is used in an async context, you could use [await import(…)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports) from CommonJS instead of require(…).

## Fixes

- [x] Might fix version [0.3.2-alpha.1](https://www.npmjs.com/package/jest-preview/v/0.3.2-alpha.1) that has a problem with update-notifier@6 being used with require. (commonjs context)

## Quick test I did:

- Faked an older version:
<img width="400" alt="Screenshot 2023-05-31 at 9 43 14" src="https://github.com/nvh95/jest-preview/assets/110400888/6cedb511-4b29-46c2-8063-8e875d04d48c">

- Created dist files by running `pnpm run build`
- Ran `node dist/cli/index.js` twice and got the following message:
<img width="400" alt="Screenshot 2023-05-31 at 9 43 09" src="https://github.com/nvh95/jest-preview/assets/110400888/1cd51df8-a14f-40e8-8a29-2e9eccedaddd">


#### PS:
- Would be nice to create a new prerelease and another round of testing to see if the change indeed works.
- Let me know if this is the right track or not, or if there's anything I could change.
