### PR TITLE
fix: add content type to preview server

### DIFF
--- a/src/cli/server/previewServer.ts
+++ b/src/cli/server/previewServer.ts
@@ -172,6 +172,7 @@ app.use('/', (req, res) => {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">`,
   );
+  res.setHeader('Content-Type', 'text/html');
   res.end(indexHtml);
 });
 


### PR DESCRIPTION
## Summary/ Motivation (TLDR;)

This allows `jest-preview` to be used in GitHub Codespaces and probably fixes other problems.

The preview server was not setting the content type header in the response.
Somehow this does not cause any problems when running in `localhost`, but it
seems like it prevents the preview from being rendered in GitHub Codespaces
environments, becuase the page gets rendered as a text file instead of html

## Related issues

<!-- Add related issue here: E.g: #124-->

- #

## Fixes

- [ ] fix content type header in the preview server
