### PR TITLE
Add tiny detail on PORT

### DIFF
--- a/website/docs/getting-started/usage.md
+++ b/website/docs/getting-started/usage.md
@@ -35,7 +35,7 @@ Optionally, you can use `npm-run-all` to run Jest and `jest-preview` server in p
 ### 2. Run the `jest-preview` server
 
 ```bash
-# You can use PORT to customize port, default to 3336
+# You can use env variable PORT to customize port, default to 3336
 npm run jest-preview
 # Or
 yarn jest-preview


### PR DESCRIPTION
I had to go into the source to find out PORT was env.PORT. 

As this was not clear in the documentation, this tiny detail might be helpful to users.


