### PR TITLE
fix: patch jest with done callback style

### DIFF
--- a/demo/__tests__/App.test.tsx
+++ b/demo/__tests__/App.test.tsx
@@ -26,4 +26,9 @@ describe('App', () => {
 
     expect(screen.getByTestId('count')).toContainHTML('7');
   });
+
+  it('should work with done when setting autoPreview:true', (done) => {
+    expect(true).toBe(true);
+    done();
+  });
 });

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -84,17 +84,27 @@ function patchJestFunction(it: RawIt) {
     if (!callback) {
       callbackWithPreview = undefined;
     } else {
-      callbackWithPreview = async function (
-        ...args: Parameters<jest.ProvidesCallback>
-      ) {
-        try {
-          // @ts-expect-error Just forward the args
-          return await callback(...args);
-        } catch (error) {
-          debug();
-          throw error;
-        }
-      };
+      if (callback.length > 0) {
+        // For `done` callback
+        callbackWithPreview = function (done: jest.DoneCallback) {
+          try {
+            return callback(done);
+          } catch (error) {
+            debug();
+            throw error;
+          }
+        };
+      } else {
+        // For sync and promise functions
+        callbackWithPreview = async function () {
+          try {
+            return await callback();
+          } catch (error) {
+            debug();
+            throw error;
+          }
+        };
+      }
     }
     return originalIt(name, callbackWithPreview, timeout);
   };


### PR DESCRIPTION
<!--
  Hi. If you can see this, thank you very much. Yes. I am talking to you, who is creating a PR to make jest-preview a better library.
  We provide a CONTRIBUTING guide at https://www.jest-preview.com/docs/others/contributing. I hope it helps you when setup and start contribute to jest-preview. (You can contribute to CONTRIBUTING as well!)
  If you have any questions, let me know at https://twitter.com/hung_dev or https://discord.gg/z4DRBmk7vx.
  I can wait to welcome you to contributors.
-->

## Summary/ Motivation (TLDR;)

Patching `jest.it` in `autoPreview` mode does not support [`done` callback style](https://jestjs.io/docs/asynchronous#callbacks) yet. This PR to patch it

## Related issues

<!-- Add related issue here: E.g: #124-->

- #314

## Test

This will fail [in `autoPreview` mode](https://www.jest-preview.com/docs/api/jestpreviewconfigure/#autopreview-boolean)
```js
it('should work with done when setting autoPreview:true', (done) => {
    expect(true).toBe(true);
    done();
  });
```
